### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,7 +12,6 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.ToolSetup
-      system_list: 'ubuntu windows macos'
       python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   UnitTesting:

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -22,6 +22,13 @@ jobs:
     with:
       jobs: ${{ needs.Params.outputs.python_jobs }}
       artifact: ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}
+      pacboy: >-
+        python-pip:p
+        python-wheel:p
+        python-coverage:p
+        python-lxml:p
+        python-ruamel-yaml:p
+        python-ruamel.yaml.clib:p
 
   Coverage:
     uses: pyTooling/Actions/.github/workflows/CoverageCollection.yml@r0

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -12,7 +12,6 @@ jobs:
     uses: pyTooling/Actions/.github/workflows/Parameters.yml@r0
     with:
       name: pyEDAA.ToolSetup
-      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       name: pyEDAA.ToolSetup
       system_list: 'ubuntu windows macos'
+      python_version_list: "3.6 3.7 3.8 3.9 3.10"
 
   UnitTesting:
     uses: pyTooling/Actions/.github/workflows/UnitTesting.yml@r0
@@ -122,15 +123,18 @@ jobs:
     with:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
+        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -128,18 +128,15 @@ jobs:
     with:
       package: ${{ fromJson(needs.Params.outputs.params).artifacts.package }}
       remaining: |
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.9
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-ubuntu-3.10
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.9
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-windows-3.10
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-msys2-3.9
-        ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.6
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.7
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.8
         ${{ fromJson(needs.Params.outputs.params).artifacts.unittesting }}-macos-3.9

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 
-pyTooling>=1.9.2
+pyTooling>=1.9.4
 
 # Enforce latest version on ReadTheDocs
 sphinx>=4.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "pyTooling >= 1.9.2",
+    "pyTooling >= 1.9.4",
     "setuptools >= 35.0.2",
     "wheel >= 0.29.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyTooling[yaml]>=1.9.2
+pyTooling[yaml]>=1.9.4
 pyTooling.TerminalUI>=1.5.6
 pyAttributes>=2.5.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,4 +9,4 @@ pytest-cov>=3.0.0
 
 # Static Type Checking
 mypy>=0.931
-lxml>=4.6.4
+lxml>=4.6


### PR DESCRIPTION
# Changes

* Bump dependencies.
* UnitTesting: do not override system_list, use pacboy to install packages on MSYS2.
* ci/Params: do not override python_version_list, since 3.6 was deprecated in pyTooling/Actions and ToolSetup needs pyTooling>=1.9.4.
